### PR TITLE
Throw an error when firehose returns an error message.

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -64,9 +64,11 @@ export class FirehoseLogger extends winston.Transport {
       meta,
     };
 
-    this.firehoser.send(JSON.stringify(message)).then(
+    return this.firehoser.send(JSON.stringify(message)).then(
       () => callback(null, true),
-      e => callback(e, false)
-    );
+      e => {
+        callback(e, false);
+        throw new Error(e);
+      });
   }
 }


### PR DESCRIPTION
At least in my case, this is the right behavior to not have errors go missing....
@pkallos 
