### PR TITLE
Adjustments to make sure things work on Lambda's node 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 before_script:
-  - npm install -g jasmine
+  - npm install jasmine winston
 node_js:
+  - "4.3"
   - "5"
   - "5.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "npm run lint && JASMINE_CONFIG_PATH=spec/support/jasmine.json jasmine",
+    "test": "npm run lint && jasmine",
     "prepublish": "npm run build",
     "lint": "eslint src spec"
   },
@@ -24,13 +24,12 @@
   },
   "homepage": "https://github.com/pkallos/winston-firehose#readme",
   "dependencies": {
-    "aws-sdk": "^2.3.14",
-    "bluebird": "^3.4.0",
-    "winston": "^2.2.0"
+    "aws-sdk": "^2.3.14"
   },
   "devDependencies": {
     "babel-cli": "^6.3.13",
     "babel-core": "^6.3.13",
+    "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "eslint": "^2.9.0",
@@ -38,7 +37,10 @@
     "eslint-plugin-import": "^1.11.1",
     "eslint-plugin-jsx-a11y": "^1.2.0",
     "eslint-plugin-react": "^5.2.2",
-    "jasmine-node": "^2.0.0"
+    "jasmine": "^2.5.2"
+  },
+  "peerDependencies": {
+    "winston": "^2.2.0"
   },
   "eslintConfig": {
     "extends": "airbnb",

--- a/spec/firehoserSpec.js
+++ b/spec/firehoserSpec.js
@@ -1,0 +1,26 @@
+const fh = require('../src/firehose.js');
+
+describe('firehoser module', () => {
+  pending('comment out this line if you want to really log something');
+  // Replace 'donkey' with a real stream name
+  const FH = new fh.FireHoser('donkey', {
+    region: 'us-east-1',
+  });
+
+  it('writes to firehose', done => {
+    const message = {
+      timestamp: (new Date()).toISOString(),
+      level: 'info',
+      message: 'test message',
+      meta: { rich: 'meta' },
+    };
+
+    FH.send(JSON.stringify(message)).then(m => {
+      console.log(m);
+      done(m);
+    }, e => {
+      console.log(e);
+      done(new Error('fudge'));
+    });
+  });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -4,7 +4,7 @@
     "**/*[sS]pec.js"
   ],
   "helpers": [
-    "../node_modules/babel-register/lib/node.js",
+    "../node_modules/babel-core/register.js",
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,

--- a/spec/support/mock-firehoser.js
+++ b/spec/support/mock-firehoser.js
@@ -1,5 +1,4 @@
 const fh = require('../../src/firehose');
-const Promise = require('bluebird');
 
 class MockFireHoser extends fh.IFireHoser {
   constructor(streamName, firehoseOptions) {

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -1,6 +1,5 @@
 const winston = require('winston');
 const AWS = require('aws-sdk');
-const Promise = require('bluebird');
 
 AWS.config.setPromisesDependency(Promise);
 


### PR DESCRIPTION
- move winston to be a peer dependency (good hygiene)
- remove bluebird and let babel handle promise
- add a disabled test that can be used to actually log a test log
- use the real jasmine test lib instead of node-jasmine
- add 4.3 test to travis
