### PR TITLE
Add support to pass the region as an additional options-param

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -52,6 +52,9 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
 
     const streamName = options.streamName;
     const firehoseOptions = options.firehoseOptions || {};
+    if (options.region) {
+      AWS.config.update({region: options.region});
+    }
 
     this.firehoser = options.firehoser || new FireHoser(streamName, firehoseOptions);
   }

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -53,7 +53,7 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
     const streamName = options.streamName;
     const firehoseOptions = options.firehoseOptions || {};
     if (options.region) {
-      AWS.config.update({region: options.region});
+      AWS.config.update({ region: options.region });
     }
 
     this.firehoser = options.firehoser || new FireHoser(streamName, firehoseOptions);


### PR DESCRIPTION
This is required when you call AWS services from outside of AWS (in our case from GCP). 

Without calling Winston on the correct region we're getting the following error message: 

"InvalidSignatureException: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details. Error: InvalidSignatureException: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details. "