### PR TITLE
Handle log callback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-firehose",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -790,9 +790,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -837,9 +837,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.cond": {

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -59,7 +59,10 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
     this.firehoser = options.firehoser || new FireHoser(streamName, firehoseOptions);
   }
 
-  log(info) {
+  log(info, callback) {
+    if (callback) {
+      setImmediate(callback);
+    }
     const message = Object.assign({ timestamp: (new Date()).toISOString() }, info);
     return this.firehoser.send(this.formatter(message));
   }


### PR DESCRIPTION
For example, running the example snippet from readme fails to put both of the log messages to the Firehose stream because callback handling is missing from the send. (tried with Winston v3.2.1)

```js
var winston = require('winston');
var WFirehose = require('winston-firehose');
 
// register the transport
var logger = winston.createLogger({
    transports: [
      new WFirehose({
        'streamName': 'firehose_stream_name',
        'firehoseOptions': {
          'region': 'us-east-1'
        }
      })
    ]
  });
 
// log away!!
// with just a string
logger.info('This is the log message!');
 
// or with meta info
logger.info('This is the log message!', { snakes: 'delicious' });
```

The execution freezes, because the first callback is not returned, and only the first message is pushed to the stream. This PR adds callback handling by setting it to be executed in the next iteration of the event loop.