### PR TITLE
Remove custom formatter and default level

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ logger.info('This is the log message!');
 logger.info('This is the log message!', { snakes: 'delicious' });
 ```
 
-This will write messages as strings (using logger or transport's format) into Firehose.
-By default `winston.format.json()` will be used:
+This will write messages as strings (using JSON.stringify) into Firehose in the following format:
 ```
 {
+  timestamp: "2016-05-20T22:48:01.106Z",
   level: "info",
   message: "This is the log message!",
   snakes: "delicious"
@@ -54,6 +54,10 @@ By default `winston.format.json()` will be used:
 
 `firehoseOptions (object) - optional/suggested` The Firehose options that are passed directly to the constructor,
  [documented by AWS here](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Firehose.html#constructor-property)
+
+ `useLoggerLevel (boolean) - optional` Use winston logger level if set to true. Transport level will default to `info` if undefined.
+
+ `useLoggerFormat (boolean) - optional` Use winston logger format if set to true. Transport format will default to `JSON.stringify` if undefined.
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ logger.info('This is the log message!');
 logger.info('This is the log message!', { snakes: 'delicious' });
 ```
 
-This will write messages as strings (using JSON.stringify) into Firehose in the following format:
+This will write messages as strings (using logger or transport's format) into Firehose.
+By default `winston.format.json()` will be used:
 ```
 {
-  timestamp: 2016-05-20T22:48:01.106Z,
   level: "info",
   message: "This is the log message!",
-  meta: { snakes: "delicious" }
+  snakes: "delicious"
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/pkallos/winston-firehose#readme",
   "dependencies": {
     "aws-sdk": "^2.3.14",
+    "triple-beam": "^1.3.0",
     "winston-transport": "^4.2.0"
   },
   "devDependencies": {

--- a/spec/firehoseLoggerLevelSpec.js
+++ b/spec/firehoseLoggerLevelSpec.js
@@ -1,0 +1,85 @@
+const winston = require('winston');
+const MockFireHoser = require('./support/mock-firehoser');
+const WFireHose = require('../src/index.js');
+
+describe('firehose logger transport level', function () {
+  beforeAll(function () {
+    this.m = new MockFireHoser('test-stream', {});
+    this.message = 'test message';
+    spyOn(this.m, 'send').and.callThrough();
+  });
+
+  beforeEach(function () {
+    this.m.send.calls.reset();
+  });
+
+  it('default level is info', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      transports: [
+        new WFireHose({
+          firehoser: m,
+        }),
+      ],
+    });
+
+    logger.info(message);
+    expect(m.send).toHaveBeenCalled();
+
+    this.m.send.calls.reset();
+    logger.debug(message);
+    expect(m.send).not.toHaveBeenCalled();
+  });
+
+  it('if option.level is defined, use the level', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      transports: [
+        new WFireHose({
+          firehoser: m,
+          level: 'warn',
+        }),
+      ],
+    });
+
+    logger.info(message);
+    expect(m.send).not.toHaveBeenCalled();
+
+    logger.warn(message);
+    expect(m.send).toHaveBeenCalled();
+  });
+
+  it('if options.useLoggerLevel is true, use logger level', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      level: 'warn',
+      transports: [
+        new WFireHose({
+          firehoser: m,
+          useLoggerLevel: true,
+        }),
+      ],
+    });
+
+    logger.info(message);
+    expect(m.send).not.toHaveBeenCalled();
+
+    logger.warn(message);
+    expect(m.send).toHaveBeenCalled();
+  });
+
+  it('if options.useLoggerLevel is false or undefined, ignore logger level', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      level: 'warn',
+      transports: [
+        new WFireHose({
+          firehoser: m,
+        }),
+      ],
+    });
+
+    logger.info(message);
+    expect(m.send).toHaveBeenCalled();
+  });
+});

--- a/spec/firhoseLoggerFormatterSpec.js
+++ b/spec/firhoseLoggerFormatterSpec.js
@@ -1,0 +1,100 @@
+const winston = require('winston');
+const MockFireHoser = require('./support/mock-firehoser');
+const WFireHose = require('../src/index.js');
+
+describe('firehose logger transport formatter', function () {
+  beforeAll(function () {
+    this.m = new MockFireHoser('test-stream', {});
+    this.message = 'test message';
+    this.meta = { snakes: 'delicious' };
+    spyOn(this.m, 'send').and.callThrough();
+  });
+
+  beforeEach(function () {
+    this.m.send.calls.reset();
+  });
+
+  it('default formatter is JSON.stringify', function () {
+    const { m, message, meta } = this;
+    const logger = winston.createLogger({
+      transports: [
+        new WFireHose({
+          firehoser: m,
+        }),
+      ],
+    });
+
+    logger.info(message, meta);
+    const actualMessage = JSON.parse(m.send.calls.argsFor(0)[0]);
+    expect(actualMessage.message).toBe(message);
+    expect(actualMessage.snakes).toBe('delicious');
+    expect(actualMessage.level).toBe('info');
+    expect(actualMessage.timestamp).toBeDefined();
+  });
+
+  it('if option.formatter is defined, use the formatter', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      transports: [
+        new WFireHose({
+          firehoser: m,
+          formatter: (info) => `formatted: ${info.message}`,
+        }),
+      ],
+    });
+
+    logger.info(message);
+    const actualMessage = m.send.calls.argsFor(0)[0];
+    expect(actualMessage).toBe(`formatted: ${message}`);
+  });
+
+  it('ignore logger format by default', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      format: winston.format.simple(),
+      transports: [
+        new WFireHose({
+          firehoser: m,
+        }),
+      ],
+    });
+
+    logger.info(message);
+    const actualMessage = JSON.parse(m.send.calls.argsFor(0)[0]);
+    expect(actualMessage.message).toBe(message);
+  });
+
+  it('if option.useLoggerFormat is defined, use the winston formatter(logger)', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      format: winston.format.simple(),
+      transports: [
+        new WFireHose({
+          firehoser: m,
+          useLoggerFormat: true,
+        }),
+      ],
+    });
+
+    logger.info(message);
+    const actualMessage = m.send.calls.argsFor(0)[0];
+    expect(actualMessage).toBe(`info: ${message}`);
+  });
+
+  it('if option.useLoggerFormat is defined, use the winston formatter(transport)', function () {
+    const { m, message } = this;
+    const logger = winston.createLogger({
+      transports: [
+        new WFireHose({
+          firehoser: m,
+          useLoggerFormat: true,
+          format: winston.format.simple(),
+        }),
+      ],
+    });
+
+    logger.info(message);
+    const actualMessage = m.send.calls.argsFor(0)[0];
+    expect(actualMessage).toBe(`info: ${message}`);
+  });
+});

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -48,6 +48,13 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
   constructor(options) {
     super(options);
     this.name = 'FirehoseLogger';
+    if (!options.useLoggerLevel) {
+      this.level = options.level || 'info';
+    }
+    if (!options.useLoggerFormat) {
+      this.formatter = options.formatter || JSON.stringify;
+    }
+
     const streamName = options.streamName;
     const firehoseOptions = options.firehoseOptions || {};
     if (firehoseOptions.region) {
@@ -61,7 +68,11 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
     if (callback) {
       setImmediate(callback);
     }
-    const message = info[MESSAGE];
+    let message = info[MESSAGE];
+    if (this.formatter) {
+      message = Object.assign({ timestamp: (new Date()).toISOString() }, info);
+      message = this.formatter(message);
+    }
     return this.firehoser.send(message);
   }
 };

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -1,5 +1,6 @@
 const Transport = require('winston-transport');
 const AWS = require('aws-sdk');
+const { MESSAGE } = require('triple-beam');
 
 AWS.config.setPromisesDependency(Promise);
 
@@ -48,7 +49,6 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
     super(options);
     this.name = 'FirehoseLogger';
     this.level = options.level || 'info';
-    this.formatter = options.formatter || JSON.stringify;
 
     const streamName = options.streamName;
     const firehoseOptions = options.firehoseOptions || {};
@@ -63,8 +63,8 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
     if (callback) {
       setImmediate(callback);
     }
-    const message = Object.assign({ timestamp: (new Date()).toISOString() }, info);
-    return this.firehoser.send(this.formatter(message));
+    const message = info[MESSAGE];
+    return this.firehoser.send(message);
   }
 };
 

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -48,8 +48,6 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
   constructor(options) {
     super(options);
     this.name = 'FirehoseLogger';
-    this.level = options.level || 'info';
-
     const streamName = options.streamName;
     const firehoseOptions = options.firehoseOptions || {};
     if (firehoseOptions.region) {


### PR DESCRIPTION
As of winston 3.x, winston and winston-transport supports custom format and level, for either the entire Logger and a particular Transport. Ignoring the logger option and having own options for them is kind of unexpected IMHO.
This PR removes custom formatter option and default level(`info`), and uses the base Transport's(or Logger's) level and format instead.

```js
var logger = winston.createLogger({
  transport: [ new FirehoseTransport({
    streamName: 'firehose-stream-name'
  }) ]
});
logger.info('This is the log message!');
// {"message":"This is the log message!","level":"info"}

var timestamplogger = winston.createLogger({
  transport: [ new FirehoseTransport({
    level: 'info',
    format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
    streamName: 'firehose-stream-name'
  }) ]
});
timestamplogger.info('This is the log message!');
// {"timestamp":"2019-12-12T11:37:21.618Z","message":"This is the log message!","level":"info"}
```

This is a breaking change so a major release has to be done if this PR is accepted and merged.