### PR TITLE
Added catch to AWS promise to allow a silent failure.

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -40,7 +40,9 @@ const FireHoser = class FireHoser extends IFireHoser {
       },
     };
 
-    return this.firehose.putRecord(params).promise();
+    return this.firehose.putRecord(params).promise().catch(() => {
+      // Do nothing?
+    });
   }
 };
 

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -40,8 +40,8 @@ const FireHoser = class FireHoser extends IFireHoser {
       },
     };
 
-    return this.firehose.putRecord(params).promise().catch(() => {
-      // Do nothing?
+    return this.firehose.putRecord(params).promise().catch((err) => {
+      console.error(err)
     });
   }
 };


### PR DESCRIPTION
According to the readme this should be failing silently. I have been tracking down an error where a long running connection in a lambda function breaks which causes a NetworkingError to throw. The error obviously messes with the lambda execution and does not silently fail. I am not sure what your contributing guidelines are, but I would be more than happy to discuss what is going on if you would like more information.