### PR TITLE
Handle errors

### DIFF
--- a/spec/firehoseLoggerSpec.js
+++ b/spec/firehoseLoggerSpec.js
@@ -3,15 +3,18 @@ const MockFireHoser = require('./support/mock-firehoser');
 const WFireHose = require('../src/index.js');
 
 describe('firehose logger transport', function () {
-  beforeAll(function () {
-    this.m = new MockFireHoser('test-stream', {});
-    this.message = 'test message';
-    spyOn(this.m, 'send').and.callThrough();
+  let mockFirehoser;
+  const message = 'test message';
+
+  beforeEach(function () {
+    jasmine.clock().mockDate(new Date('Fri Aug 06 2021 15:17:28 GMT-0400 (Eastern Daylight Time)'));
+
+    mockFirehoser = new MockFireHoser('test-stream', {});
+    spyOn(mockFirehoser, 'send').and.callThrough();
   });
 
   it('logs a message', function (done) {
-    const { m, message } = this;
-    m.send(message)
+    mockFirehoser.send(message)
       .then(response => {
         expect(response).toBe(message);
         done();
@@ -20,15 +23,14 @@ describe('firehose logger transport', function () {
   });
 
   it('affixes to winston', function () {
-    const { m, message } = this;
-    m.send.calls.reset();
     const logger = winston.createLogger({
       transports: [
-        new WFireHose({ firehoser: m }),
+        new WFireHose({ firehoser: mockFirehoser }),
       ],
     });
 
     logger.info(message);
-    expect(m.send).toHaveBeenCalled();
+
+    expect(mockFirehoser.send).toHaveBeenCalled();
   });
 });

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -65,6 +65,7 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
   }
 
   log(info, callback) {
+    // Fire and forget so we don't back up the stream.
     if (callback) {
       setImmediate(callback);
     }
@@ -73,7 +74,14 @@ const FirehoseLogger = class FirehoseLogger extends Transport {
       message = Object.assign({ timestamp: (new Date()).toISOString() }, info);
       message = this.formatter(message);
     }
-    return this.firehoser.send(message);
+    this.firehoser
+      .send(message)
+      .then(() => {
+        this.emit('logged', message);
+      })
+      .catch((err) => {
+        this.emit('error', err);
+      });
   }
 };
 


### PR DESCRIPTION
Fixes bug where an error from AWS Firehose will throw an uncaught exception. Now it will emit an 'error' event instead. This is in line with Winston's own HTTP transport [here](https://github.com/winstonjs/winston/blob/master/lib/winston/transports/http.js#L51) and also the popular Winston Elasticsearch transport [here](https://github.com/vanthome/winston-elasticsearch/blob/master/index.js#L109).

In looking at how this should be handled, I looked into other popular Winston transports and realize many call `callback` after some async action:
- https://github.com/lazywithclass/winston-cloudwatch/blob/master/index.js - Waits for the HTTP response. 
- https://github.com/winstonjs/winston-mongodb/blob/master/lib/winston-mongodb.js#L228 - Waits until after writing to mongodb. 
- https://github.com/winstonjs/winston-syslog/blob/master/lib/winston-syslog.js#L183 - Waits until after writing.

Presumably this will back up the stream. Per the comment in Winston's HTTP transport [here](https://github.com/winstonjs/winston/blob/master/lib/winston/transports/http.js#L64), it appears to be recommended to make it fire-and-forget, and then emit an error event afterwards.

One small hazard with this change is that if someone passed in their own Firehoser via the `firehose` option and its send() function didn't return a promise, this update would now cause an exception. So this update is technically a breaking API change. However, it looks like it was always expected that the Firehoser's `send()` call returns a promise from the base class documentation [here](https://github.com/pkallos/winston-firehose/blob/c84dd88974afe0bf1984b32fbd71a1788cbaa511/src/firehose.js#L18). The code prior to the Winston 3 upgrade also expected a promise [here](https://github.com/pkallos/winston-firehose/pull/15/files#diff-82a4cd50d58745c66a19eed180aa6d846bc01ee10e6065c064a6a4bc1323d4c6L67).

This also emits a 'logged' event that's in line with Winston's transport example. Unlike the 'error' event, 'logged' is not listened to by Winston, so we can emit anything. I think it makes most sense to log the actual string we sent to Firehose.