### PR TITLE
add dependabot config with grouped upgrade PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+    groups:
+      winston:
+        patterns:
+          - winston
+          - winston-transport
+          - logform
+          - triple-beam
+          - "@types/triple-beam"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+          - "@smithy/*"
+      dev-tooling:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    cooldown:
+      default-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml`. There was no dependabot config before this — the 15 npm deps and 4 pinned GitHub Action refs (`actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, `changesets/action`) had no automated update path.

- **npm**, weekly (Monday 06:00), `versioning-strategy: increase-if-necessary` so the `winston` peer range floor (`^3.19.0`) only moves when a release actually falls outside it, not on every compatible minor — this repo publishes `winston` as a peer dep, so a floor bump forces every downstream consumer to upgrade.
  - group `winston` + `winston-transport` + `logform` + `triple-beam` + `@types/triple-beam` — they release in lockstep and `winston` is both a `devDependency` and `peerDependency`.
  - group `@aws-sdk/*` + `@smithy/*` — `@aws-sdk/client-firehose` releases almost daily; without grouping it would dominate the PR queue.
  - group remaining dev-tooling **minor/patch** bumps only. Majors (`typescript`, `vitest`, `@biomejs/biome`, `tsdown`) are deliberately left ungrouped so each lands as its own PR — these are exactly the deps whose majors tend to break `typecheck`/`test`, and a grouped PR failing on one hides the rest.
  - `ignore` `@types/node` majors — `engines.node` is `>=22`, so types should describe the oldest supported runtime rather than outrunning it.
  - `cooldown`: 3 days default, 7 for majors, so a freshly-broken release doesn't land immediately (security updates are never delayed by cooldown).
- **github-actions**, same weekly schedule, all four action refs grouped into one PR — CI runs on that PR either way, so a bad bump is self-evident.

## Notes for follow-up (not fixed in this PR)

- `spec/integration/firehose.spec.ts` pins `localstack/localstack:4.14.0` in a TS string literal. Dependabot's `docker` ecosystem only scans Dockerfiles/compose files, so this pin has no automated update path.
- The repo is in changesets prerelease mode (`.changeset/pre.json`, tag `next`). Dependency PRs merged without an accompanying changeset won't trigger a release.
- Dependabot's handling of the `packageManager` field (`pnpm@10.22.0`) and of `peerDependencies` entries isn't documented by GitHub either way — worth watching the first few PRs to see what it actually touches.

## Test plan

- [x] Validated the YAML parses and the `winston`/`aws-sdk` groups are ordered before the `dev-tooling` catch-all (group order determines precedence when a dependency matches multiple patterns).
- [ ] Confirm GitHub's dependabot.yml validation passes (Insights → Dependency graph → Dependabot) after this merges.
- [ ] Watch the first grouped PRs to confirm the winston/aws-sdk/dev-tooling groupings behave as designed.
