### PR TITLE
guard against manual publishes clobbering the latest npm tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ The first deploy in a fresh AWS account/region also creates SST's own account-le
 `sst-asset-*`/`sst-state-*` bucket pair and an `sst-asset` ECR repo, all empty for this stack).
 `sst remove` doesn't touch these by design, since other SST apps in the account may reuse them —
 they won't show up in the `winston-firehose:test` tag sweep above.
+
+### Releasing
+
+Releases are automated by changesets (`.github/workflows/release.yml`): merging its "Version
+Packages" PR publishes to npm. While `.changeset/pre.json` has the package in prerelease mode,
+`publishConfig.tag` in `package.json` pins the default npm dist-tag to `next`, so a manual
+`npm publish` (bypassing the automated pipeline) can't accidentally overwrite `latest` with a
+prerelease. Remove that `tag` field when running `pnpm changeset pre exit` to ship the first
+stable release, or the stable version will itself publish under `next` instead of `latest`.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "winston": "^3.19.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "next"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- The npmjs.com `latest` tag has pointed at the abandoned `4.0.0-next.0` prerelease since 2023 - a one-off manual `npm publish` with no `--tag` flag, so npm's default landed it on `latest`.
- Today's automated release pipeline (`changeset publish`) is unaffected since it always passes `--tag next` explicitly while `.changeset/pre.json` is in prerelease mode. But nothing stopped a manual `npm publish` from repeating the exact same mistake.
- Pins `publishConfig.tag` to `next` in `package.json` so any manual publish while in prerelease mode defaults to `next` instead of clobbering `latest`, and documents the release flow (and the need to remove this field on `changeset pre exit`) in the README.

The stale `latest` dist-tag itself still needs a one-time fix on the registry (`npm dist-tag add winston-firehose@3.0.2 latest`), which requires npm publish auth this environment doesn't have.

## Test plan
- [x] `node -e "JSON.parse(...)"` confirms `package.json` stays valid JSON
- [ ] CI (lint/typecheck/test/build/publint/attw/smoke-test) passes