### PR TITLE
exit changesets prerelease mode for the 4.0.0 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "winston-firehose": "4.0.0-next.0"

--- a/README.md
+++ b/README.md
@@ -104,9 +104,6 @@ they won't show up in the `winston-firehose:test` tag sweep above.
 
 ### Releasing
 
-Releases are automated by changesets (`.github/workflows/release.yml`): merging its "Version
-Packages" PR publishes to npm. While `.changeset/pre.json` has the package in prerelease mode,
-`publishConfig.tag` in `package.json` pins the default npm dist-tag to `next`, so a manual
-`npm publish` (bypassing the automated pipeline) can't accidentally overwrite `latest` with a
-prerelease. Remove that `tag` field when running `pnpm changeset pre exit` to ship the first
-stable release, or the stable version will itself publish under `next` instead of `latest`.
+Releases are automated by changesets (`.github/workflows/release.yml`): pushing changesets to
+`master` makes it open a "Version Packages" PR bumping the version and CHANGELOG; merging that PR
+publishes to npm and cuts a GitHub release.

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "winston": "^3.19.0"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "next"
+    "access": "public"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- exit changesets prerelease mode (`.changeset/pre.json`: `pre` → `exit`) so the next release run versions and publishes stable 4.0.0 instead of another `next` prerelease
- drop `publishConfig.tag: "next"` from `package.json` — it only existed to stop a manual `npm publish` clobbering `latest` while in prerelease
- update the README "Releasing" section to describe the steady-state flow instead of the prerelease-exit instructions

## Test plan
- [x] `pnpm exec changeset status --verbose` reports a major bump to `4.0.0` from all three staged changesets
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm test` (32 unit tests)
- [x] `pnpm run build` (tsdown + attw + publint, all clean)
- [x] `pnpm run smoke-test` (CJS + ESM consumer install/import)
- [x] `pnpm run test:integration` (LocalStack, 4 passed / 4 skipped — S3-delivery assertions correctly skip on the non-S3 backend)
- [x] merge this PR, confirm changesets/action opens a "Version Packages" PR bumping to `4.0.0`, then merge that to publish
