### PR TITLE
buffer log messages into a single firehose record

### DIFF
--- a/.changeset/buffered-firehose-records.md
+++ b/.changeset/buffered-firehose-records.md
@@ -1,0 +1,5 @@
+---
+"winston-firehose": minor
+---
+
+Add an optional `buffering` option that concatenates log messages into a single Firehose record, so a run of small lines is billed as one record instead of one each, flushed by message count, buffered size, a timeout, `logger.close()`, or `transport.flush()`.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,40 @@ consumers who need custom credentials, middleware, or retry behavior. Takes prec
 
 `eol (string) - optional` End of line delimiter appended to each message before it's sent to Firehose. Defaults to `""` (no delimiter).
 
+`buffering (object) - optional` Concatenates messages into a single Firehose record instead of sending
+a record per message. Omit it to send each message on its own. See [Buffering](#buffering).
+
+## Buffering
+
+Firehose bills [per record, in 5KB increments](https://aws.amazon.com/kinesis/data-firehose/pricing/),
+so a 200-byte log line costs the same as a 5KB one. Buffering packs a run of small lines into one
+record, which is where the saving comes from:
+
+```javascript
+new FirehoseTransport({
+  streamName: "firehose_stream_name",
+  eol: "\n",
+  buffering: {
+    bufferSize: 500, // messages to hold before sending a record
+    bufferSizeKb: 5, // buffered KiB to hold before sending a record
+    flushTimeout: 30000, // ms a partial record waits before being sent anyway
+  },
+});
+```
+
+Every field is optional, and the values above are the defaults. `bufferSizeKb` defaults to Firehose's
+5KB billing increment because there's no further per-byte saving above it, only more messages to lose
+if the process dies; Firehose caps a record at `1000` KiB. `bufferSize` defaults to the 500 records
+Firehose will
+[de-aggregate from one blob](https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord.html).
+
+A record is its messages concatenated, byte for byte the same as what separate records deliver, so
+`eol` is what a downstream consumer needs to split them apart, with or without buffering.
+
+Whatever is still buffered is sent when the logger is closed (`logger.close()`). For a short-lived
+process that doesn't close its logger (a Lambda handler, say), `await transport.flush()` sends it on
+demand.
+
 ## Details
 
 At the moment this logger sends (unacknowledged!) log messages into firehose. The behavior if the log
@@ -80,7 +114,8 @@ separate suite against a real Firehose API emulated by [LocalStack](https://www.
 in a Docker container (via `testcontainers`), and requires Docker to be running locally.
 
 `pnpm test:aws` runs the same contract again against **real AWS**, plus S3-delivery assertions
-LocalStack can't provide (the `eol` framing, byte fidelity, and zero-buffering configuration). It
+LocalStack can't provide (the `eol` framing, byte fidelity, buffered-record delivery, and the
+zero-buffering configuration). It
 deploys a throwaway stack with [SST](https://sst.dev/) — an S3 bucket, an IAM role, and a Firehose
 delivery stream with zero buffering — runs the suite against it, and tears it down again, including
 on Ctrl-C. It's local/on-demand only, never run in CI. Needs AWS credentials in the environment;

--- a/spec/buffered-sender.spec.ts
+++ b/spec/buffered-sender.spec.ts
@@ -1,0 +1,317 @@
+import { BufferedSender } from "@/buffered-sender.js";
+import type { MessageSender } from "@/firehose-sender.js";
+import { RecordingSender } from "./support/harness.js";
+
+/** A sender whose sends only settle when the test says so, for ordering assertions. */
+class BlockingSender implements MessageSender {
+  readonly sent: string[] = [];
+  private readonly settle: Array<() => void> = [];
+
+  send(message: string): Promise<unknown> {
+    this.sent.push(message);
+    return new Promise<void>((resolve) => this.settle.push(resolve));
+  }
+
+  /** Settles the nth send, oldest first. */
+  release(index: number): void {
+    this.settle[index]?.();
+  }
+}
+
+describe("buffered sender", () => {
+  it("holds messages until the record is full", async () => {
+    const inner = new RecordingSender();
+    const sender = new BufferedSender(inner, { bufferSize: 3 });
+
+    const first = sender.send("a");
+    const second = sender.send("b");
+    expect(inner.sent).toEqual([]);
+
+    const third = sender.send("c");
+    await Promise.all([first, second, third]);
+
+    expect(inner.sent).toEqual(["abc"]);
+  });
+
+  it("flushes before a message that would overflow the record", async () => {
+    const inner = new RecordingSender();
+    // 1 KiB of room and 400-byte messages: the third one doesn't fit.
+    const sender = new BufferedSender(inner, { bufferSizeKb: 1 });
+    const message = "x".repeat(400);
+
+    const first = sender.send(message);
+    const second = sender.send(message);
+    const third = sender.send(message);
+    await Promise.all([first, second]);
+
+    expect(inner.sent).toEqual([message.repeat(2)]);
+
+    await sender.flush();
+    await third;
+    expect(inner.sent).toEqual([message.repeat(2), message]);
+  });
+
+  it("fills a record to exactly the byte cap without spilling into the next one", async () => {
+    const inner = new RecordingSender();
+    const sender = new BufferedSender(inner, { bufferSizeKb: 1 });
+    const half = "x".repeat(512);
+
+    await Promise.all([sender.send(half), sender.send(half)]);
+
+    expect(inner.sent).toEqual([half + half]);
+  });
+
+  it("measures the record in bytes, not characters", async () => {
+    const inner = new RecordingSender();
+    const sender = new BufferedSender(inner, { bufferSizeKb: 1 });
+    // 512 four-byte emoji is 2 KiB, so this alone overflows a 1 KiB record.
+    const message = "🔥".repeat(512);
+
+    await sender.send(message);
+
+    expect(inner.sent).toEqual([message]);
+  });
+
+  it("sends a message larger than the record cap on its own", async () => {
+    const inner = new RecordingSender();
+    const sender = new BufferedSender(inner, { bufferSizeKb: 1 });
+    const big = "x".repeat(2048);
+
+    await sender.send(big);
+
+    expect(inner.sent).toEqual([big]);
+  });
+
+  it("resolves every message in a record with the sender's result", async () => {
+    const result = { RecordId: "one-record" };
+    const inner: MessageSender = { send: () => Promise.resolve(result) };
+    const sender = new BufferedSender(inner, { bufferSize: 2 });
+
+    const [first, second] = await Promise.all([sender.send("a"), sender.send("b")]);
+
+    expect(first).toBe(result);
+    expect(second).toBe(result);
+  });
+
+  it("buffers messages that arrive while a record is in flight into the next one", async () => {
+    const inner = new BlockingSender();
+    const sender = new BufferedSender(inner, { bufferSize: 2 });
+
+    void sender.send("a");
+    void sender.send("b");
+    await Promise.resolve();
+    expect(inner.sent).toEqual(["ab"]);
+
+    void sender.send("c");
+    void sender.send("d");
+    await Promise.resolve();
+    expect(inner.sent).toEqual(["ab"]);
+
+    inner.release(0);
+    await vi.waitFor(() => expect(inner.sent).toEqual(["ab", "cd"]));
+  });
+
+  it("preserves message order within a record", async () => {
+    const inner = new RecordingSender();
+    const sender = new BufferedSender(inner, { bufferSize: 3 });
+
+    await Promise.all([sender.send("one\n"), sender.send("two\n"), sender.send("three\n")]);
+
+    expect(inner.sent).toEqual(["one\ntwo\nthree\n"]);
+  });
+
+  describe("flush timeout", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("flushes a partial record once the timeout elapses", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, { flushTimeout: 5_000 });
+
+      const pending = sender.send("a");
+      vi.advanceTimersByTime(4_999);
+      expect(inner.sent).toEqual([]);
+
+      vi.advanceTimersByTime(1);
+      await pending;
+      expect(inner.sent).toEqual(["a"]);
+    });
+
+    it("defaults to a 30 second timeout", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, {});
+
+      const pending = sender.send("a");
+      vi.advanceTimersByTime(29_999);
+      expect(inner.sent).toEqual([]);
+
+      vi.advanceTimersByTime(1);
+      await pending;
+      expect(inner.sent).toEqual(["a"]);
+    });
+
+    it("times out from the first message of a record, not the last", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, { flushTimeout: 5_000 });
+
+      const first = sender.send("a");
+      vi.advanceTimersByTime(4_000);
+      const second = sender.send("b");
+      vi.advanceTimersByTime(1_000);
+
+      await Promise.all([first, second]);
+      expect(inner.sent).toEqual(["ab"]);
+    });
+
+    it("doesn't send an empty record when the buffer is already drained", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, { bufferSize: 1, flushTimeout: 5_000 });
+
+      await sender.send("a");
+      vi.advanceTimersByTime(60_000);
+
+      expect(inner.sent).toEqual(["a"]);
+    });
+
+    it("starts a fresh window for the record after one is sent", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, { bufferSize: 2, flushTimeout: 5_000 });
+
+      await Promise.all([sender.send("a"), sender.send("b")]);
+
+      const third = sender.send("c");
+      vi.advanceTimersByTime(5_000);
+      await third;
+
+      expect(inner.sent).toEqual(["ab", "c"]);
+    });
+
+    it("drops the pending timeout once the record has been flushed by hand", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, { bufferSize: 100, flushTimeout: 5_000 });
+
+      await Promise.all([sender.send("a"), sender.flush()]);
+      vi.advanceTimersByTime(60_000);
+
+      expect(inner.sent).toEqual(["a"]);
+    });
+  });
+
+  it("leaves the flush timer unreferenced, so it can't hold the process open", async () => {
+    const handles: NodeJS.Timeout[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      ...args: Parameters<typeof setTimeout>
+    ) => {
+      const handle = realSetTimeout(...args);
+      handles.push(handle);
+      return handle;
+    }) as typeof setTimeout);
+
+    const sender = new BufferedSender(new RecordingSender(), { bufferSize: 100 });
+    void sender.send("a");
+
+    expect(handles).toHaveLength(1);
+    expect(handles[0].hasRef()).toBe(false);
+
+    vi.restoreAllMocks();
+    await sender.flush();
+  });
+
+  describe("flush", () => {
+    it("sends whatever is buffered", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, { bufferSize: 100 });
+
+      const pending = sender.send("a");
+      await sender.flush();
+
+      expect(inner.sent).toEqual(["a"]);
+      await pending;
+    });
+
+    it("does nothing when there's nothing buffered", async () => {
+      const inner = new RecordingSender();
+      const sender = new BufferedSender(inner, {});
+
+      await sender.flush();
+
+      expect(inner.sent).toEqual([]);
+    });
+
+    it("waits for a record already in flight", async () => {
+      const inner = new BlockingSender();
+      const sender = new BufferedSender(inner, { bufferSize: 1 });
+
+      void sender.send("a");
+      await Promise.resolve();
+      let settled = false;
+      const flushed = sender.flush().then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      inner.release(0);
+      await flushed;
+      expect(settled).toBe(true);
+    });
+  });
+
+  it("rejects every message in a record that fails to send", async () => {
+    const inner = new RecordingSender();
+    inner.failNext(new Error("send failure"));
+    const sender = new BufferedSender(inner, { bufferSize: 2 });
+
+    const first = sender.send("a");
+    const second = sender.send("b");
+
+    await expect(first).rejects.toThrow("send failure");
+    await expect(second).rejects.toThrow("send failure");
+  });
+
+  it("keeps sending records after one fails", async () => {
+    const inner = new RecordingSender();
+    const sender = new BufferedSender(inner, { bufferSize: 1 });
+
+    inner.failNext(new Error("send failure"));
+    await expect(sender.send("a")).rejects.toThrow("send failure");
+
+    inner.recover();
+    await sender.send("b");
+    expect(inner.sent).toEqual(["b"]);
+  });
+
+  it("sends records in the order they were buffered", async () => {
+    const inner = new BlockingSender();
+    const sender = new BufferedSender(inner, { bufferSize: 1 });
+
+    void sender.send("first");
+    await Promise.resolve();
+    void sender.send("second");
+    await Promise.resolve();
+
+    // One record in flight at a time, so a slow send can't be overtaken by a later one.
+    expect(inner.sent).toEqual(["first"]);
+
+    inner.release(0);
+    await vi.waitFor(() => expect(inner.sent).toEqual(["first", "second"]));
+  });
+
+  it.each([
+    ["bufferSize", { bufferSize: 0 }],
+    ["bufferSizeKb", { bufferSizeKb: 0 }],
+    ["bufferSizeKb above the firehose record limit", { bufferSizeKb: 1_001 }],
+    ["flushTimeout", { flushTimeout: 0 }],
+    ["bufferSize that isn't a number", { bufferSize: Number.NaN }],
+    ["unbounded bufferSize", { bufferSize: Number.POSITIVE_INFINITY }],
+  ])("rejects an out of range %s", (_label, options) => {
+    expect(() => new BufferedSender(new RecordingSender(), options)).toThrow(RangeError);
+  });
+});

--- a/spec/buffering.spec.ts
+++ b/spec/buffering.spec.ts
@@ -1,0 +1,117 @@
+import type winston from "winston";
+import { makeLogger } from "./support/harness.js";
+
+/** winston writes one entry per turn of the loop, so each log needs a tick to land. */
+async function logAll(logger: winston.Logger, messages: readonly string[]): Promise<void> {
+  for (const message of messages) {
+    logger.info(message);
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+const MESSAGES = ["one", "two", "three"] as const;
+
+describe("firehose logger transport buffering", () => {
+  it("sends each message as its own record when buffering isn't configured", async () => {
+    const { logger, sent } = makeLogger();
+
+    await logAll(logger, MESSAGES);
+
+    expect(sent).toHaveLength(MESSAGES.length);
+  });
+
+  it("aggregates several log lines into one record", async () => {
+    const { logger, sent, transport } = makeLogger({
+      buffering: { bufferSize: MESSAGES.length },
+      eol: "\n",
+    });
+
+    await logAll(logger, MESSAGES);
+    await transport.flush();
+
+    expect(sent).toHaveLength(1);
+    const lines = sent[0].split("\n").filter(Boolean);
+    expect(lines.map((line) => JSON.parse(line).message)).toEqual([...MESSAGES]);
+  });
+
+  it("sends the record once the formatted lines reach bufferSizeKb", async () => {
+    const { logger, sent } = makeLogger({ buffering: { bufferSizeKb: 1 }, eol: "\n" });
+    // Two lines of this go past 1 KiB, so the second one sends the first on its own.
+    const wide = "x".repeat(600);
+
+    await logAll(logger, [wide, wide]);
+
+    await vi.waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0].split("\n").filter(Boolean)).toHaveLength(1);
+  });
+
+  it("sends a partial record when the flush timeout elapses", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { logger, transport, sent } = makeLogger({ buffering: { flushTimeout: 1_000 } });
+      const logged = new Promise((resolve) => transport.once("logged", resolve));
+
+      await logAll(logger, ["one"]);
+      expect(sent).toEqual([]);
+
+      vi.advanceTimersByTime(1_000);
+      await logged;
+
+      expect(sent).toHaveLength(1);
+      expect(JSON.parse(sent[0]).message).toBe("one");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('emits "logged" per message with that message alone, not the record', async () => {
+    const { logger, transport } = makeLogger({ buffering: { bufferSize: 2 } });
+
+    const logged: string[] = [];
+    transport.on("logged", (message: string) => logged.push(message));
+
+    await logAll(logger, ["one", "two"]);
+
+    await vi.waitFor(() =>
+      expect(logged.map((line) => JSON.parse(line).message)).toEqual(["one", "two"]),
+    );
+  });
+
+  it('emits "error" for every message in a record that fails', async () => {
+    const { logger, sender } = makeLogger({ buffering: { bufferSize: 2 } });
+    sender.failNext(new Error("send failure"));
+
+    // On the logger, not the transport: winston re-emits transport errors there, and
+    // its own listener runs first.
+    const errors: Error[] = [];
+    logger.on("error", (err: Error) => errors.push(err));
+
+    await logAll(logger, ["one", "two"]);
+
+    await vi.waitFor(() =>
+      expect(errors).toEqual([new Error("send failure"), new Error("send failure")]),
+    );
+  });
+
+  it("flushes buffered messages when the logger closes", async () => {
+    const { logger, sent } = makeLogger({ buffering: { bufferSize: 100 } });
+
+    await logAll(logger, MESSAGES);
+    expect(sent).toEqual([]);
+
+    // No explicit flush: closing the logger is the only thing sending what's buffered.
+    logger.close();
+
+    await vi.waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0]).toContain("three");
+  });
+
+  it("flushes nothing when buffering isn't configured", async () => {
+    const { logger, transport, sent } = makeLogger();
+
+    await logAll(logger, ["one"]);
+    await expect(transport.flush()).resolves.toBeUndefined();
+
+    expect(sent).toHaveLength(1);
+  });
+});

--- a/spec/integration/contract.ts
+++ b/spec/integration/contract.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { DescribeDeliveryStreamCommand, FirehoseClient } from "@aws-sdk/client-firehose";
 import winston from "winston";
+import { BufferedSender } from "@/buffered-sender.js";
 import { FirehoseSender } from "@/firehose-sender.js";
 import { FirehoseTransport } from "@/firehose-transport.js";
 import type { DeliveredObjectReader, FirehoseBackend, FirehoseTarget } from "./support/backend.js";
@@ -31,6 +32,30 @@ async function logSerially(
     sent.push(await logged);
   }
   return sent;
+}
+
+/**
+ * Logs every message through a buffering transport and returns the lines it sent. They
+ * can't be awaited one at a time the way `logSerially` does it: a buffered message only
+ * reports `logged` once the whole record carrying it lands.
+ */
+async function logBuffered(
+  transport: FirehoseTransport,
+  logger: winston.Logger,
+  messages: readonly string[],
+): Promise<string[]> {
+  const logged: string[] = [];
+  transport.on("logged", (line: string) => logged.push(line));
+
+  for (const message of messages) {
+    logger.info(message);
+    // winston writes one entry per turn of the loop.
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  await transport.flush();
+  await vi.waitFor(() => expect(logged).toHaveLength(messages.length));
+
+  return logged;
 }
 
 const EOL_TEST_MESSAGES = ["one", "two", "three"] as const;
@@ -112,6 +137,45 @@ export function describeFirehoseContract(backend: FirehoseBackend): void {
 
       const message = await logged;
       expect(JSON.parse(message).message).toBe("sent through a caller-supplied client");
+    });
+
+    it("buffers several messages into a single firehose record", async () => {
+      const sender = new BufferedSender(new FirehoseSender(target.streamName, client), {
+        bufferSize: EOL_TEST_MESSAGES.length,
+      });
+
+      const results = await Promise.all(
+        EOL_TEST_MESSAGES.map((message) => sender.send(`${message}\n`)),
+      );
+
+      // One `PutRecord` result shared by all three: the real API took a single billable
+      // record, which no assertion against the delivered bytes could tell apart.
+      expect(new Set(results).size).toBe(1);
+    });
+
+    it("sends a partial record once the flush timeout elapses", async () => {
+      const sender = new BufferedSender(new FirehoseSender(target.streamName, client), {
+        bufferSize: 100,
+        flushTimeout: 500,
+      });
+
+      // Nothing flushes this by hand, so the timer is the only thing that can send it.
+      const result = await sender.send("sent by the flush timeout\n");
+
+      expect(result).toHaveProperty("RecordId");
+    });
+
+    it("fills a record to the default buffer size and the api takes it", async () => {
+      const sender = new BufferedSender(new FirehoseSender(target.streamName, client), {
+        bufferSize: 50,
+      });
+      // 50 of these is 5,050 bytes, just under the 5 KiB `bufferSizeKb` default, so the
+      // record goes out full: the shape the default config actually produces.
+      const line = `${"x".repeat(100)}\n`;
+
+      const results = await Promise.all(Array.from({ length: 50 }, () => sender.send(line)));
+
+      expect(new Set(results).size).toBe(1);
     });
 
     it("emits an error for a delivery stream that doesn't exist", async () => {
@@ -213,6 +277,132 @@ export function describeFirehoseContract(backend: FirehoseBackend): void {
         expect(() => JSON.parse(jammed)).toThrow();
       },
     );
+
+    it.skipIf(!backend.deliversToS3)(
+      "delivers a buffered record as the same newline-delimited lines",
+      async () => {
+        const marker = randomUUID();
+        const transport = new FirehoseTransport({
+          streamName: target.streamName,
+          firehoseOptions: target.firehoseOptions,
+          eol: "\n",
+          buffering: { bufferSize: EOL_TEST_MESSAGES.length },
+        });
+        const logger = winston.createLogger({ transports: [transport] });
+
+        const logged = await logBuffered(
+          transport,
+          logger,
+          EOL_TEST_MESSAGES.map((message) => `${marker} ${message}`),
+        );
+
+        const run = logged.join("");
+        const object = await delivered().waitForObjectContaining(run);
+
+        const start = object.body.indexOf(run);
+        const lines = object.body
+          .slice(start, start + run.length)
+          .split("\n")
+          .filter(Boolean);
+        expect(lines.map((line) => JSON.parse(line).message)).toEqual(
+          EOL_TEST_MESSAGES.map((message) => `${marker} ${message}`),
+        );
+      },
+    );
+
+    it.skipIf(!backend.deliversToS3)(
+      "without eol, a buffered record is jammed together like separate records",
+      async () => {
+        // The equivalence the whole design rests on: aggregating changes what a record
+        // costs, never what reaches the destination. Only the delivered bytes can show
+        // that buffering neither adds a separator of its own nor drops one.
+        const marker = randomUUID();
+        const transport = new FirehoseTransport({
+          streamName: target.streamName,
+          firehoseOptions: target.firehoseOptions,
+          buffering: { bufferSize: EOL_TEST_MESSAGES.length },
+        });
+        const logger = winston.createLogger({ transports: [transport] });
+
+        const logged = await logBuffered(
+          transport,
+          logger,
+          EOL_TEST_MESSAGES.map((message) => `${marker} ${message}`),
+        );
+
+        const run = logged.join("");
+        const object = await delivered().waitForObjectContaining(run);
+
+        const start = object.body.indexOf(run);
+        const jammed = object.body.slice(start, start + run.length);
+        expect(jammed).toMatch(/\}\{/);
+        expect(jammed).not.toContain("\n");
+        expect(() => JSON.parse(jammed)).toThrow();
+      },
+    );
+
+    it.skipIf(!backend.deliversToS3)("delivers a record filled to the cap intact", async () => {
+      // A near-full record of multi-byte lines, which is where a sizing or encoding bug
+      // would show up: the buffer is measured in bytes but the blob is built from a string,
+      // and Firehose de-aggregates blobs of its own accord.
+      const marker = randomUUID();
+      const lineCount = 50;
+      const transport = new FirehoseTransport({
+        streamName: target.streamName,
+        firehoseOptions: target.firehoseOptions,
+        formatter: (info) => `${marker} ${info.message} 日本語 🔥`,
+        eol: "\n",
+        buffering: { bufferSize: lineCount },
+      });
+      const logger = winston.createLogger({ transports: [transport] });
+
+      const logged = await logBuffered(
+        transport,
+        logger,
+        Array.from({ length: lineCount }, (_, index) => `${index}`.padStart(4, "0").repeat(11)),
+      );
+
+      const run = logged.join("");
+      // 97 bytes a line, so the record sits just under the 5 KiB `bufferSizeKb` default.
+      const bytes = Buffer.byteLength(run);
+      expect(bytes).toBeGreaterThan(4 * 1024);
+      expect(bytes).toBeLessThanOrEqual(5 * 1024);
+
+      const object = await delivered().waitForObjectContaining(run);
+
+      const start = object.body.indexOf(run);
+      const lines = object.body
+        .slice(start, start + run.length)
+        .split("\n")
+        .filter(Boolean);
+      expect(lines).toHaveLength(lineCount);
+    });
+
+    it.skipIf(!backend.deliversToS3)("delivers consecutive records in the order sent", async () => {
+      // The chaining invariant end to end: two records, and the wait below only resolves
+      // once one object holds the second directly behind the first.
+      const marker = randomUUID();
+      const messages = ["one", "two", "three", "four"].map((message) => `${marker} ${message}`);
+      const transport = new FirehoseTransport({
+        streamName: target.streamName,
+        firehoseOptions: target.firehoseOptions,
+        eol: "\n",
+        buffering: { bufferSize: 2 },
+      });
+      const logger = winston.createLogger({ transports: [transport] });
+
+      const logged = await logBuffered(transport, logger, messages);
+
+      const run = logged.join("");
+      const object = await delivered().waitForObjectContaining(run);
+
+      const start = object.body.indexOf(run);
+      const lines = object.body
+        .slice(start, start + run.length)
+        .split("\n")
+        .filter(Boolean);
+      expect(lines.map((line) => JSON.parse(line).message)).toEqual(messages);
+    });
 
     it.skipIf(!backend.deliversToS3)("delivers the formatted bytes verbatim", async () => {
       const marker = randomUUID();

--- a/spec/support/harness.ts
+++ b/spec/support/harness.ts
@@ -17,6 +17,11 @@ export class RecordingSender implements MessageSender {
   failNext(error: Error): void {
     this.failure = error;
   }
+
+  /** Undoes `failNext`, so sends are recorded again. */
+  recover(): void {
+    this.failure = undefined;
+  }
 }
 
 /**

--- a/src/buffered-sender.ts
+++ b/src/buffered-sender.ts
@@ -1,0 +1,154 @@
+import type { MessageSender } from "@/firehose-sender.js";
+
+/**
+ * Firehose {@link https://aws.amazon.com/kinesis/data-firehose/pricing/ | bills a record in
+ * 5 KB increments}, so filling one to 5 KB is where the saving is. Past that there's none
+ * left to take, only more messages to lose if the process dies.
+ */
+const DEFAULT_BUFFER_SIZE_KB = 5;
+
+/**
+ * Firehose de-aggregates at most 500 records out of one blob, so a fuller record would
+ * break a consumer that relies on it.
+ * @see {@link https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord.html}
+ */
+const DEFAULT_BUFFER_SIZE = 500;
+
+const DEFAULT_FLUSH_TIMEOUT = 30_000;
+
+/**
+ * Firehose rejects a record whose data blob exceeds 1,000 KiB.
+ * @see {@link https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord.html}
+ */
+const MAX_RECORD_SIZE_KB = 1_000;
+
+const BYTES_PER_KB = 1_024;
+
+export type BufferingOptions = {
+  /** Messages to hold before sending a record. Defaults to `500`. */
+  bufferSize?: number;
+
+  /**
+   * Buffered bytes to hold before sending a record, in KiB. Defaults to `5`, the increment
+   * Firehose bills in; `1000` is the largest record it accepts.
+   */
+  bufferSizeKb?: number;
+
+  /** Milliseconds a partial record waits before being sent anyway. Defaults to `30000`. */
+  flushTimeout?: number;
+};
+
+function positive(label: string, value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${label} must be greater than 0, got ${value}`);
+  }
+  return value;
+}
+
+type Buffered = {
+  readonly message: string;
+  readonly resolve: (result: unknown) => void;
+  readonly reject: (error: unknown) => void;
+};
+
+/**
+ * Concatenates messages into one Firehose record before handing them to `sender`,
+ * so a run of small log lines is billed as one record instead of one each.
+ *
+ * A record is its messages joined end to end, byte for byte what separate records
+ * deliver, so splitting them apart downstream depends on the transport's `eol`.
+ */
+export class BufferedSender implements MessageSender {
+  private readonly maxMessages: number;
+  private readonly maxBytes: number;
+  private readonly flushTimeout: number;
+  private buffer: Buffered[] = [];
+  private bufferedBytes = 0;
+  private timer?: NodeJS.Timeout;
+  private inFlight: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly sender: MessageSender,
+    options: BufferingOptions,
+  ) {
+    this.maxMessages = positive("bufferSize", options.bufferSize ?? DEFAULT_BUFFER_SIZE);
+    this.flushTimeout = positive("flushTimeout", options.flushTimeout ?? DEFAULT_FLUSH_TIMEOUT);
+
+    const sizeKb = positive("bufferSizeKb", options.bufferSizeKb ?? DEFAULT_BUFFER_SIZE_KB);
+    if (sizeKb > MAX_RECORD_SIZE_KB) {
+      throw new RangeError(
+        `bufferSizeKb must be at most ${MAX_RECORD_SIZE_KB}, the largest record firehose accepts, got ${sizeKb}`,
+      );
+    }
+    this.maxBytes = sizeKb * BYTES_PER_KB;
+  }
+
+  /** Resolves once the record holding `message` has been sent, not when it's buffered. */
+  send(message: string): Promise<unknown> {
+    const bytes = Buffer.byteLength(message);
+    if (this.buffer.length > 0 && this.bufferedBytes + bytes > this.maxBytes) {
+      this.sendRecord();
+    }
+
+    const sent = new Promise<unknown>((resolve, reject) => {
+      this.buffer.push({ message, resolve, reject });
+    });
+    this.bufferedBytes += bytes;
+
+    if (this.buffer.length === 1) this.startTimer();
+    if (this.buffer.length >= this.maxMessages || this.bufferedBytes >= this.maxBytes) {
+      this.sendRecord();
+    }
+
+    return sent;
+  }
+
+  /**
+   * Sends whatever is buffered and waits for every record still in flight. Resolves
+   * whether or not those records made it: a failure reaches the caller through the
+   * `send` promise of each message it carried.
+   */
+  async flush(): Promise<void> {
+    this.sendRecord();
+    await this.inFlight.catch(() => {});
+  }
+
+  private sendRecord(): void {
+    this.clearTimer();
+    if (this.buffer.length === 0) return;
+
+    const record = this.buffer;
+    this.buffer = [];
+    this.bufferedBytes = 0;
+    const data = record.map((entry) => entry.message).join("");
+
+    // Chained rather than sent concurrently, so records reach the stream in the order
+    // they were buffered even when one send is slow.
+    const sent = this.inFlight.then(
+      () => this.sender.send(data),
+      () => this.sender.send(data),
+    );
+    this.inFlight = sent;
+
+    sent.then(
+      (result) => {
+        for (const entry of record) entry.resolve(result);
+      },
+      (error: unknown) => {
+        for (const entry of record) entry.reject(error);
+      },
+    );
+  }
+
+  private startTimer(): void {
+    this.timer = setTimeout(() => this.sendRecord(), this.flushTimeout);
+    // Never let a partial record hold the process open.
+    this.timer.unref?.();
+  }
+
+  private clearTimer(): void {
+    if (this.timer === undefined) return;
+    clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+}

--- a/src/firehose-sender.ts
+++ b/src/firehose-sender.ts
@@ -7,6 +7,9 @@ import {
 /** A destination for formatted log lines. Implement this to swap the real Firehose call out in tests. */
 export interface MessageSender {
   send(message: string): Promise<unknown>;
+
+  /** Sends anything held back and waits for it. Only senders that buffer implement this. */
+  flush?(): Promise<void>;
 }
 
 /** Sends records to an AWS Kinesis Firehose delivery stream via the SDK v3 client. */

--- a/src/firehose-transport.ts
+++ b/src/firehose-transport.ts
@@ -2,6 +2,7 @@ import { FirehoseClient, type FirehoseClientConfig } from "@aws-sdk/client-fireh
 import type { TransformableInfo } from "logform";
 import { MESSAGE } from "triple-beam";
 import Transport, { type TransportStreamOptions } from "winston-transport";
+import { BufferedSender, type BufferingOptions } from "@/buffered-sender.js";
 import { FirehoseSender, type MessageSender } from "@/firehose-sender.js";
 
 export type FormatterFunc = (info: TransformableInfo) => string;
@@ -53,6 +54,14 @@ export type FirehoseTransportOptions = TransportStreamOptions & {
   /** End of line delimiter appended to each message. Defaults to `""`. */
   eol?: string;
 
+  /**
+   * Concatenates messages into one Firehose record instead of sending a record each,
+   * since Firehose bills a record in 5 KB increments. Omit it to send every message on
+   * its own. Aggregated messages arrive concatenated, so set `eol` to a delimiter if
+   * anything downstream has to split them apart.
+   */
+  buffering?: BufferingOptions;
+
   /** Test seam: overrides both `firehoseOptions` and `firehoseClient` entirely. */
   firehoseSender?: MessageSender;
 };
@@ -75,7 +84,8 @@ export class FirehoseTransport extends Transport {
     this.eol = options.eol ?? "";
 
     const client = options.firehoseClient ?? new FirehoseClient(options.firehoseOptions ?? {});
-    this.sender = options.firehoseSender ?? new FirehoseSender(options.streamName, client);
+    const sender = options.firehoseSender ?? new FirehoseSender(options.streamName, client);
+    this.sender = options.buffering ? new BufferedSender(sender, options.buffering) : sender;
   }
 
   log(info: TransformableInfo, callback?: () => void): void {
@@ -88,5 +98,19 @@ export class FirehoseTransport extends Transport {
       () => this.emit("logged", message),
       (err: unknown) => this.emit("error", err),
     );
+  }
+
+  /**
+   * Sends any buffered messages and waits for what's in flight. A no-op unless
+   * `buffering` is configured. Send failures surface as `error` events rather than
+   * rejecting here.
+   */
+  flush(): Promise<void> {
+    return this.sender.flush?.() ?? Promise.resolve();
+  }
+
+  /** Called by winston when the logger closes, so buffered messages aren't dropped. */
+  close(): void {
+    void this.flush();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { BufferedSender, type BufferingOptions } from "@/buffered-sender.js";
 export { FirehoseSender, type MessageSender } from "@/firehose-sender.js";
 export {
   FirehoseTransport,


### PR DESCRIPTION
closes #13.

firehose bills [per record, in 5kb increments](https://aws.amazon.com/kinesis/data-firehose/pricing/), so a 200-byte log line costs the same as a 5kb one. this adds an optional `buffering` option that concatenates messages into one record before sending it.

```javascript
new FirehoseTransport({
  streamName: "firehose_stream_name",
  eol: "\n",
  buffering: { bufferSize: 500, bufferSizeKb: 5, flushTimeout: 30000 },
});
```

off unless `buffering` is set, so nothing changes for existing consumers.

## why one record instead of PutRecordBatch

batching 500 small records into one api call saves api calls, not money. billing is per record either way. concatenating them into a single record payload is what cuts the bill.

## defaults

the values in the snippet above are the defaults:

- `bufferSizeKb: 5` is the billing increment. above it there's no further per-byte saving, only more messages to lose if the process dies.
- `bufferSize: 500` is the most records firehose will [de-aggregate out of one blob](https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord.html).
- `flushTimeout: 30000`, the value proposed in the issue.

`bufferSizeKb` over 1000 throws at construction, since that's the largest record firehose accepts.

## behavior worth a look in review

a record is its messages joined end to end, byte for byte what separate records already deliver (the existing "without eol, records are delivered jammed together" contract test pins that down). so `eol` stays the thing a consumer needs in order to split lines, buffered or not, and there are no implicit delimiter defaults.

buffered messages go out on `logger.close()`: winston unpipes the transport, which calls `close()`. `transport.flush()` covers a short-lived process that never closes its logger, a lambda handler for instance.

records are chained, one in flight at a time, so a slow send can't let a later record overtake it into the stream. the flush timer is unref'd, so a partial record never holds the process open. `logged` and `error` still fire per message, once the record carrying it lands.

## testing

tests first, then the code. 35 new unit tests. `spec/buffered-sender.spec.ts` covers the count, byte and timeout thresholds (including the exact-fit boundary), ordering within a record and across records, messages that arrive while a record is in flight, the unref'd timer, error propagation and recovery, and option validation. `spec/buffering.spec.ts` covers the transport wiring, the events, and close.

three of those were checked by mutation rather than assumed: dropping the `unref`, moving the byte boundary by one, and unchaining the records each fail a test.

seven new contract tests on the integration side. three run against both backends: all messages resolving with one shared `PutRecord` result, which is how you can tell the real api took a single billable record instead of one each, the timeout path driven by a real client, and a record filled to the 5 KiB default.

the other four are s3-gated, because delivered bytes are the only place they can be checked. a buffered record splits back into the same newline-delimited lines. a buffered record with no `eol` is jammed together exactly like separate records, which is the equivalence the whole design rests on. a near-full record of multi-byte lines arrives intact and unsplit, firehose having done no de-aggregation of its own. two consecutive records land in the order they were sent.

green locally: unit, `pnpm run test:integration` against localstack, lint, typecheck, `pnpm run smoke-test`, and `pnpm test:aws` against a real deployed stack in us-east-1. all 15 contract tests pass there, including every s3-gated one, so the buffered bytes really do land in s3 as claimed. the stack tore down clean, with nothing left behind under the `winston-firehose:test` tag.
