### PR TITLE
prepare release workflow for npm trusted publishing

### DIFF
--- a/.changeset/changesets-cli-v3.md
+++ b/.changeset/changesets-cli-v3.md
@@ -1,0 +1,5 @@
+---
+"winston-firehose": patch
+---
+
+`dist` is byte-identical to 4.0.0; the only change is the `@changesets/cli` dev dependency moving to v3.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -18,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Winston Firehose](https://www.philkallos.com/winston-firehose/)
+# Winston Firehose
 
 NodeJS module, winston logging transport which writes to AWS Firehose.
 


### PR DESCRIPTION
npm removes direct publish from 2FA-bypass granular tokens in **January 2027** ([changelog](https://github.blog/changelog/2026-07-31-restricting-npm-bypass-2fa-granular-access-tokens/)). The migration path is trusted publishing over OIDC. This PR clears the one blocker that would make that switch fail, without changing how publishing works today.

## the blocker

OIDC needs npm >= 11.5.1. `release.yml` pinned `node-version: 22`, which ships **npm 10.9.4**. Node 24 ships 11.5.1. So trusted publishing would have failed on this repo even with npmjs.com configured correctly, and the failure would have shown up as a broken release rather than anything obvious.

pnpm has no OIDC support of its own, so it's worth being precise about why OIDC is reachable here at all. `changeset publish` selects a publish tool and returns pnpm for this repo, and pnpm 10 then delegates the actual publish to the npm CLI through `runNpm()`. The npm CLI performs the OIDC exchange, which is why the npm version on the runner is the thing that matters.

## changes

- `node-version: 22` -> `24` in the release job
- `id-token: write` added to `permissions`
- readme heading no longer links to the GitHub Pages site, which is being taken down
- a patch changeset, so merging this cuts 4.0.1

`registry-url` and `NODE_AUTH_TOKEN` are untouched. Publishing keeps running on `NPM_TOKEN` until a trusted publisher is configured on npmjs.com.

## why node 24 is safe here

`.npmrc` sets `engine-strict=true`, so an unsatisfied engine range is a hard install failure rather than a warning. What makes this safe:

- `build.yml` already runs a `24.x` matrix leg with `pnpm install --frozen-lockfile` and it passes on master. `tsdown` requires `>=24.11.0`, so that green run is proof the runner's Node 24 is at or above 24.11.
- `@changesets/cli@3` declares `^22.11 || ^24 || >=26`
- the 22.x leg is unchanged, so consumers on Node 22 are still covered by CI

## validation

Ran on this branch under Node 22.22.1: lint, typecheck, 67 unit tests, build, publint, attw, all clean. `changeset status` reports `patch - winston-firehose`, confirming the changeset is picked up and this produces 4.0.1.

Node 24 is covered by the `24.x` CI leg rather than locally, because my machine is on 24.7.0 and `engine-strict` correctly rejects it against `tsdown`.

## after this merges

Cutting 4.0.1 is the point: the `NODE_AUTH_TOKEN` publish path introduced in #51 has never actually published anything, because every release run so far has no-opped. This is the first real exercise of it.

Heads up that the Version Packages PR will need its CI approved by hand. It gets authored by `github-actions[bot]`, so its runs land in `action_required` and never start on their own. There are already three abandoned runs like that on `changeset-release/master`.
